### PR TITLE
Package.json: use cross-env for setting NODE_OPTIONS

### DIFF
--- a/Workload/package.json
+++ b/Workload/package.json
@@ -4,9 +4,9 @@
   "description": "Microsoft Fabric - Developer Sample App",
   "scripts": {
     "start": "npm run start:devServer",
-    "start:devServer": "set NODE_OPTIONS=--max-old-space-size=8192 && env-cmd -f .env.dev webpack serve --open --config ./devServer/webpack.dev.js",
+    "start:devServer": "cross-env NODE_OPTIONS=--max-old-space-size=8192 env-cmd -f .env.dev webpack serve --open --config ./devServer/webpack.dev.js",
     "start:devGateway": "node ./devServer/start-devGateway.js",
-    "start:codespace": "node --max-old-space-size=8192 ./node_modules/.bin/env-cmd -f .env.dev webpack serve --open --config ./devServer/webpack.dev.js --no-hot",
+    "start:codespace": "cross-env NODE_OPTIONS=--max-old-space-size=8192 env-cmd -f .env.dev webpack serve --open --config ./devServer/webpack.dev.js --no-hot",
     "build:test": "env-cmd -f .env.test webpack --config ./webpack.config.js --output-path ../build/Frontend --progress",
     "build:prod": "env-cmd -f .env.prod webpack --config ./webpack.config.js --output-path ../build/Frontend --mode production --progress"
   },
@@ -38,6 +38,7 @@
     "ajv": "^8.12.0",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^10.0.0",
+    "cross-env": "^7.0.3",
     "css-loader": "^6.5.1",
     "dotenv": "^16.4.5",
     "env-cmd": "^10.1.0",


### PR DESCRIPTION
Replace the Windows-only set NODE_OPTIONS=... with cross-env to set the NODE_OPTIONS environment variable in the start:devServer script. cross-env sets environment variables consistently across all platforms.

Changes:

Use cross-env NODE_OPTIONS=--max-old-space-size=8192 in start:devServer + start:codespace
Add cross-env@^7.0.3 as a devDependency